### PR TITLE
Add CVar "mp_plant_c4_anywhere_delay" + API member. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ This means that plugins that do binary code analysis (Orpheu for example) probab
 | sv_allchat                         | 1       | 0   | 1            | Players can receive all other players text chat, team restrictions apply<br/>`0` disabled <br/>`1` enabled |
 | sv_autobunnyhopping                | 0       | 0   | 1            | Players automatically re-jump while holding jump button.<br/>`0` disabled <br/>`1` enabled |
 | sv_enablebunnyhopping              | 0       | 0   | 1            | Allow player speed to exceed maximum running speed.<br/>`0` disabled <br/>`1` enabled |
+| mp_plant_c4_anywhere_delay         | 0       | -1  | -            | When set, players can plant the C4 anywhere (according to the delay in seconds when > 0), not only in bomb sites.<br/>`<0` - no delay<br/>`0` - disabled (default behaviour, a player must be on a bomb site in order to plant)<br/>`>0` - delay to wait |
 </details>
 
 ## How to install zBot for CS 1.6?

--- a/dist/game.cfg
+++ b/dist/game.cfg
@@ -476,3 +476,11 @@ sv_autobunnyhopping 0
 //
 // Default value: "0"
 sv_enablebunnyhopping 0
+
+// Number of seconds to delay (after round start) before a player having a C4 can plant it anywhere.
+// <0 - no delay
+// 0 - disabled (default behaviour, a player must be on a bomb site in order to plant)
+// >0 - delay to wait
+//
+// Default value: "0"
+mp_plant_c4_anywhere_delay 0

--- a/regamedll/dlls/API/CSPlayer.cpp
+++ b/regamedll/dlls/API/CSPlayer.cpp
@@ -532,7 +532,7 @@ void CCSPlayer::Reset()
 
 	m_bForceShowMenu = false;
 	m_flRespawnPending =
-		m_flSpawnProtectionEndTime = 0.0f;
+	m_flSpawnProtectionEndTime = 0.0f;
 
 	m_vecOldvAngle = g_vecZero;
 	m_iWeaponInfiniteAmmo = 0;
@@ -541,6 +541,7 @@ void CCSPlayer::Reset()
 	m_bGameForcingRespawn = false;
 	m_bAutoBunnyHopping = false;
 	m_bMegaBunnyJumping = false;
+	m_flPlantC4AnywhereDelay = -2.0f;
 }
 
 void CCSPlayer::OnSpawn()

--- a/regamedll/dlls/game.cpp
+++ b/regamedll/dlls/game.cpp
@@ -161,6 +161,7 @@ cvar_t free_armor                        = { "mp_free_armor", "0", 0, 0.0f, null
 cvar_t allchat                           = { "sv_allchat", "0", 0, 0.0f, nullptr };
 cvar_t sv_autobunnyhopping               = { "sv_autobunnyhopping", "0", 0, 0.0f, nullptr };
 cvar_t sv_enablebunnyhopping             = { "sv_enablebunnyhopping", "0", 0, 0.0f, nullptr };
+cvar_t plant_c4_anywhere_delay           = { "mp_plant_c4_anywhere_delay", "0", FCVAR_SERVER, 0.0f, nullptr };
 
 void GameDLL_Version_f()
 {
@@ -391,6 +392,7 @@ void EXT_FUNC GameDLLInit()
 	CVAR_REGISTER(&allchat);
 	CVAR_REGISTER(&sv_autobunnyhopping);
 	CVAR_REGISTER(&sv_enablebunnyhopping);
+	CVAR_REGISTER(&plant_c4_anywhere_delay);
 
 	// print version
 	CONSOLE_ECHO("ReGameDLL version: " APP_VERSION "\n");

--- a/regamedll/dlls/game.h
+++ b/regamedll/dlls/game.h
@@ -187,6 +187,7 @@ extern cvar_t free_armor;
 extern cvar_t allchat;
 extern cvar_t sv_autobunnyhopping;
 extern cvar_t sv_enablebunnyhopping;
+extern cvar_t plant_c4_anywhere_delay;
 
 #endif
 

--- a/regamedll/dlls/gamerules.h
+++ b/regamedll/dlls/gamerules.h
@@ -683,7 +683,8 @@ public:
 
 	// has a style of gameplay when aren't any teams
 	bool IsFreeForAll() const;
-	bool CanPlayerBuy(CBasePlayer *pPlayer) const;
+	EXPORT bool CanPlayerBuy(CBasePlayer *pPlayer);
+	EXPORT float GetPlantC4AnywhereDelay(CBasePlayer *pPlayer);
 
 	VFUNC bool HasRoundTimeExpired();
 	VFUNC bool IsBombPlanted();

--- a/regamedll/dlls/multiplay_gamerules.cpp
+++ b/regamedll/dlls/multiplay_gamerules.cpp
@@ -5141,7 +5141,7 @@ void CHalfLifeMultiplay::ChangePlayerTeam(CBasePlayer *pPlayer, const char *pTea
 	}
 }
 
-bool CHalfLifeMultiplay::CanPlayerBuy(CBasePlayer *pPlayer) const
+bool CHalfLifeMultiplay::CanPlayerBuy(CBasePlayer *pPlayer)
 {
 	if (pPlayer->m_iTeam == CT && m_bCTCantBuy)
 	{
@@ -5157,4 +5157,27 @@ bool CHalfLifeMultiplay::CanPlayerBuy(CBasePlayer *pPlayer) const
 	}
 
 	return true;
+}
+
+float CHalfLifeMultiplay::GetPlantC4AnywhereDelay(CBasePlayer *pPlayer)
+{
+#ifdef REGAMEDLL_ADD
+	float flPlantC4AnywhereDelay = -2.0f;
+
+	#ifdef REGAMEDLL_API
+	if(pPlayer && pPlayer->IsPlayer())
+	{
+		flPlantC4AnywhereDelay = pPlayer->CSPlayer()->m_flPlantC4AnywhereDelay;
+	}
+	#endif
+
+	if(flPlantC4AnywhereDelay <= -2.0f)
+	{
+		flPlantC4AnywhereDelay = plant_c4_anywhere_delay.value;
+	}
+
+	return flPlantC4AnywhereDelay;
+#else
+	return 0.0f;
+#endif	
 }

--- a/regamedll/public/regamedll/API/CSPlayer.h
+++ b/regamedll/public/regamedll/API/CSPlayer.h
@@ -48,7 +48,8 @@ public:
 		m_bCanShootOverride(false),
 		m_bGameForcingRespawn(false),
 		m_bAutoBunnyHopping(false),
-		m_bMegaBunnyJumping(false)
+		m_bMegaBunnyJumping(false),
+		m_flPlantC4AnywhereDelay(-2.0f)
 	{
 		m_szModel[0] = '\0';
 	}
@@ -129,6 +130,7 @@ public:
 	bool m_bGameForcingRespawn;
 	bool m_bAutoBunnyHopping;
 	bool m_bMegaBunnyJumping;
+	float m_flPlantC4AnywhereDelay;
 };
 
 // Inlines

--- a/regamedll/public/regamedll/regamedll_api.h
+++ b/regamedll/public/regamedll/regamedll_api.h
@@ -38,7 +38,7 @@
 #include <API/CSInterfaces.h>
 
 #define REGAMEDLL_API_VERSION_MAJOR 5
-#define REGAMEDLL_API_VERSION_MINOR 21
+#define REGAMEDLL_API_VERSION_MINOR 22
 
 // CBasePlayer::Spawn hook
 typedef IHookChainClass<void, class CBasePlayer> IReGameHook_CBasePlayer_Spawn;

--- a/regamedll/version/version.h
+++ b/regamedll/version/version.h
@@ -6,5 +6,5 @@
 #pragma once
 
 #define VERSION_MAJOR		5
-#define VERSION_MINOR		21
+#define VERSION_MINOR		22
 #define VERSION_MAINTENANCE	0


### PR DESCRIPTION
Add CVar "mp_plant_c4_anywhere_delay" + API member CCSPlayer's "m_flPlantC4AnywhereDelay" to allow per-client setting.
I made work the CVar to support a delay (or none when set to "-1") from the round start, because this is a bit abused to have that feature active from beginning! Like teams spawns then 5 seconds later "The bomb has been planted!".
Then I have also added a message informing the player who wants to plant outside from a bomb site that "he has to wait * second(s)", but the problem with that is there is no localization string (#*) on the client (so no game translations), so this is discutable, despite I think this worth to inform him about the feature.
So maybe we can discuss about it if you devs are against or not, or, what the overall player base is thinking.

**About API member addition:**
The new member CCSPlayer's "m_flPlantC4AnywhereDelay" has "2.0" as defaut "unconsidered value", this is in order to allow per-client support of "restriction" (if set to "0") instead of redirecting in such case to the CVar. The only workaround to support this kind of feature is to set the CVar to 0 & set per-client settings via the member, so it is easier the way I did.
Also, I have updated ReGameDLL_CS's API minor because any addition to API even in the class "CCSEntity" worth to increment this (to know the new member requires a specific API version of ReGameDLL_CS, despite the "commits number" could be used as workaround for such "tiny" thing).

**Extra notes:**
Also added "EXPORT" label to 2 functions of the class "CHalfLifeMultiplay" in order to allow easy retrieval of the function address via symbol under Windows (like under Linux).
I could also make them "virtual" but I prefered to do not in order to avoid breaking already existing virtual IDs listing ("HasRoundTimeExpired" + "IsBombPlanted" being at the suite...) & AMXX's ReAPI module using full CSSDK (and not only the "pure public ReAPI interfaces" like my own [AMX's ReAPI](https://www.amxmod.net/forum/showthread.php?tid=1522) module).

The kind of per-client API member could be added for a lot of other features (mp_buytime, mp_buy_anywhere, mp_forcerespawn, mp_freeforall, etc.), I basically have plans to do it because this allows customization per-client & so interesting, like if you want to enable FFA for only 1 client (like I have this on my public classic server, I can TK my teammates (the dumb ones!) this counts as frag! Hehehehehe!).

**PS**: I did not see someone already pushed similar PR [here](https://github.com/s1lentq/ReGameDLL_CS/pull/692) some hours before, and I had mine ready from yesterday, but mine is more "advanced" and does not deal with signals (not sure if it is the best but at least client carring the C4 can know if he is on a bomb site... as indiction). Feel free to choose which one you want!