### PR TITLE
Add CVar "mp_plant_c4_delay" + API member.

### DIFF
--- a/regamedll/dlls/API/CSPlayer.cpp
+++ b/regamedll/dlls/API/CSPlayer.cpp
@@ -258,7 +258,7 @@ EXT_FUNC CBaseEntity *CCSPlayer::GiveNamedItemEx(const char *pszName)
 
 	if (FStrEq(pszName, "weapon_c4")) {
 		pPlayer->m_bHasC4 = true;
-		pPlayer->SetBombIcon();
+		pPlayer->SetBombIcon(((pPlayer->m_signals.GetState() & SIGNAL_BOMB) && (CSGameRules()->CanPlantBomb(pPlayer) & GR_CANPLANTBOMB_DELAY_OVER)));
 
 		if (pPlayer->m_iTeam == TERRORIST) {
 			pPlayer->pev->body = 1;
@@ -531,8 +531,8 @@ void CCSPlayer::Reset()
 	m_szModel[0] = '\0';
 
 	m_bForceShowMenu = false;
-	m_flRespawnPending =
-		m_flSpawnProtectionEndTime = 0.0f;
+	m_flRespawnPending = 0.0f;
+	m_flSpawnProtectionEndTime = 0.0f;
 
 	m_vecOldvAngle = g_vecZero;
 	m_iWeaponInfiniteAmmo = 0;
@@ -541,6 +541,8 @@ void CCSPlayer::Reset()
 	m_bGameForcingRespawn = false;
 	m_bAutoBunnyHopping = false;
 	m_bMegaBunnyJumping = false;
+	m_iCanPlantC4Anywhere = -1;
+	m_flPlantC4Delay = -1.0;
 }
 
 void CCSPlayer::OnSpawn()

--- a/regamedll/dlls/game.cpp
+++ b/regamedll/dlls/game.cpp
@@ -162,6 +162,7 @@ cvar_t allchat                           = { "sv_allchat", "0", 0, 0.0f, nullptr
 cvar_t sv_autobunnyhopping               = { "sv_autobunnyhopping", "0", 0, 0.0f, nullptr };
 cvar_t sv_enablebunnyhopping             = { "sv_enablebunnyhopping", "0", 0, 0.0f, nullptr };
 cvar_t plant_c4_anywhere                 = { "mp_plant_c4_anywhere", "0", 0, 0.0f, nullptr };
+cvar_t plant_c4_delay                    = { "mp_plant_c4_delay", "0", 0, 0.0f, nullptr };
 
 void GameDLL_Version_f()
 {
@@ -393,6 +394,7 @@ void EXT_FUNC GameDLLInit()
 	CVAR_REGISTER(&sv_autobunnyhopping);
 	CVAR_REGISTER(&sv_enablebunnyhopping);
 	CVAR_REGISTER(&plant_c4_anywhere);
+	CVAR_REGISTER(&plant_c4_delay);
 
 	// print version
 	CONSOLE_ECHO("ReGameDLL version: " APP_VERSION "\n");

--- a/regamedll/dlls/game.h
+++ b/regamedll/dlls/game.h
@@ -188,6 +188,7 @@ extern cvar_t allchat;
 extern cvar_t sv_autobunnyhopping;
 extern cvar_t sv_enablebunnyhopping;
 extern cvar_t plant_c4_anywhere;
+extern cvar_t plant_c4_delay;
 
 #endif
 

--- a/regamedll/dlls/gamerules.h
+++ b/regamedll/dlls/gamerules.h
@@ -202,7 +202,6 @@ enum
 	SCENARIO_BLOCK_PRISON_ESCAPE_TIME      = BIT(8), // flag "i"
 	SCENARIO_BLOCK_BOMB_TIME               = BIT(9), // flag "j"
 	SCENARIO_BLOCK_HOSTAGE_RESCUE_TIME     = BIT(10), // flag "k"
-	
 };
 
 // Player relationship return codes
@@ -213,6 +212,14 @@ enum
 	GR_ENEMY,
 	GR_ALLY,
 	GR_NEUTRAL,
+};
+
+// Custom enum (used with custom function "CHalfLifeMultiplay::CanPlantBomb").
+enum
+{
+	GR_CANPLANTBOMB_NONE       = 0,
+	GR_CANPLANTBOMB_ANYWHERE   = BIT(0),
+	GR_CANPLANTBOMB_DELAY_OVER = BIT(1),
 };
 
 class CItem;
@@ -683,7 +690,8 @@ public:
 
 	// has a style of gameplay when aren't any teams
 	bool IsFreeForAll() const;
-	bool CanPlayerBuy(CBasePlayer *pPlayer) const;
+	EXPORT bool CanPlayerBuy(CBasePlayer *pPlayer);
+	EXPORT int CanPlantBomb(CBasePlayer *pPlayer, float *pflPlantC4Delay = nullptr);
 
 	VFUNC bool HasRoundTimeExpired();
 	VFUNC bool IsBombPlanted();

--- a/regamedll/dlls/multiplay_gamerules.cpp
+++ b/regamedll/dlls/multiplay_gamerules.cpp
@@ -5141,20 +5141,70 @@ void CHalfLifeMultiplay::ChangePlayerTeam(CBasePlayer *pPlayer, const char *pTea
 	}
 }
 
-bool CHalfLifeMultiplay::CanPlayerBuy(CBasePlayer *pPlayer) const
+bool CHalfLifeMultiplay::CanPlayerBuy(CBasePlayer *pPlayer)
 {
-	if (pPlayer->m_iTeam == CT && m_bCTCantBuy)
-	{
+	if((m_bCTCantBuy && m_bTCantBuy)
+	|| (pPlayer->m_iTeam == CT && m_bCTCantBuy)
+	|| (pPlayer->m_iTeam == TERRORIST && m_bTCantBuy))
 		return false;
-	}
-	else if (pPlayer->m_iTeam == TERRORIST && m_bTCantBuy)
-	{
-		return false;
-	}
-	else if (m_bCTCantBuy && m_bTCantBuy)
-	{
-		return false;
-	}
 
 	return true;
 }
+
+// Check if the C4 can be planted (only by rules).
+// Note: Implement team check here when a player is passed in order to easily allow tricking, if needed (but facultative).
+int CHalfLifeMultiplay::CanPlantBomb(CBasePlayer *pPlayer, float *pflPlantC4Delay)
+{
+	if(pflPlantC4Delay)
+	{
+		*pflPlantC4Delay = 0.0f;
+	}
+
+	if(pPlayer && pPlayer->IsPlayer() && !(pPlayer->m_iTeam == TERRORIST || pPlayer->m_iTeam == CT))
+		return GR_CANPLANTBOMB_NONE;
+
+#ifdef REGAMEDLL_ADD
+	int iResultFlags        = GR_CANPLANTBOMB_NONE;
+	int iCanPlantC4Anywhere = -1;
+	float flPlantC4Delay    = -1.0;
+
+	#ifdef REGAMEDLL_API
+	if(pPlayer && pPlayer->IsPlayer())
+	{
+		iCanPlantC4Anywhere = pPlayer->CSPlayer()->m_iCanPlantC4Anywhere;
+		flPlantC4Delay      = pPlayer->CSPlayer()->m_flPlantC4Delay;
+	}
+	#endif
+
+	if(iCanPlantC4Anywhere <= -1)
+	{
+		iCanPlantC4Anywhere = plant_c4_anywhere.value;
+	}
+
+	if(flPlantC4Delay <= -1.0)
+	{
+		flPlantC4Delay = plant_c4_delay.value;
+	}
+	flPlantC4Delay = Q_max(flPlantC4Delay, 0.0f);
+
+	if(pflPlantC4Delay)
+	{
+		*pflPlantC4Delay = flPlantC4Delay;
+	}
+
+	if(iCanPlantC4Anywhere >= 1)
+	{
+		iResultFlags |= GR_CANPLANTBOMB_ANYWHERE;
+	}
+
+	if(flPlantC4Delay <= (gpGlobals->time - CSGameRules()->m_fRoundStartTime))
+	{
+		iResultFlags |= GR_CANPLANTBOMB_DELAY_OVER;
+	}
+
+	return iResultFlags;
+#else
+	return GR_CANPLANTBOMB_DELAY_OVER;
+#endif
+}
+

--- a/regamedll/dlls/observer.cpp
+++ b/regamedll/dlls/observer.cpp
@@ -355,7 +355,11 @@ void CBasePlayer::Observer_CheckProperties()
 
 		if (target->m_bHasC4)
 		{
+#ifdef REGAMEDLL_ADD
+			if ((target->m_signals.GetState() & SIGNAL_BOMB) && (CSGameRules()->CanPlantBomb(target) & GR_CANPLANTBOMB_DELAY_OVER))
+#else
 			if (target->m_signals.GetState() & SIGNAL_BOMB)
+#endif
 				targetBombState = STATUSICON_FLASH;
 			else
 				targetBombState = STATUSICON_SHOW;

--- a/regamedll/dlls/unisignals.h
+++ b/regamedll/dlls/unisignals.h
@@ -28,11 +28,15 @@
 
 #pragma once
 
+// Default CS's signals.
 #define SIGNAL_BUY       BIT(0)
 #define SIGNAL_BOMB      BIT(1)
 #define SIGNAL_RESCUE    BIT(2)
 #define SIGNAL_ESCAPE    BIT(3)
 #define SIGNAL_VIPSAFETY BIT(4)
+// ReGameDLL_CS's specific signals.
+// Note: Jump to +5 in order to predict possible new flags that could be added by a legit update of the game (by VALVe).
+#define SIGNAL_BOMB_DELAY_OVER BIT(10) // Note: Used to specify the player has his plant C4 delay over or not (to blink/unblink the C4 icon when value changed and if player is on site).
 
 class CUnifiedSignals
 {

--- a/regamedll/public/regamedll/API/CSPlayer.h
+++ b/regamedll/public/regamedll/API/CSPlayer.h
@@ -49,7 +49,8 @@ public:
 		m_bGameForcingRespawn(false),
 		m_bAutoBunnyHopping(false),
 		m_bMegaBunnyJumping(false),
-		m_bPlantC4Anywhere(false)
+		m_iCanPlantC4Anywhere(-1),
+		m_flPlantC4Delay(-1.0)
 	{
 		m_szModel[0] = '\0';
 	}
@@ -130,7 +131,8 @@ public:
 	bool m_bGameForcingRespawn;
 	bool m_bAutoBunnyHopping;
 	bool m_bMegaBunnyJumping;
-	bool m_bPlantC4Anywhere;
+	int m_iCanPlantC4Anywhere;
+	float m_flPlantC4Delay;
 };
 
 // Inlines

--- a/regamedll/public/regamedll/regamedll_api.h
+++ b/regamedll/public/regamedll/regamedll_api.h
@@ -38,7 +38,7 @@
 #include <API/CSInterfaces.h>
 
 #define REGAMEDLL_API_VERSION_MAJOR 5
-#define REGAMEDLL_API_VERSION_MINOR 21
+#define REGAMEDLL_API_VERSION_MINOR 22
 
 // CBasePlayer::Spawn hook
 typedef IHookChainClass<void, class CBasePlayer> IReGameHook_CBasePlayer_Spawn;

--- a/regamedll/version/version.h
+++ b/regamedll/version/version.h
@@ -6,5 +6,5 @@
 #pragma once
 
 #define VERSION_MAJOR		5
-#define VERSION_MINOR		21
+#define VERSION_MINOR		22
 #define VERSION_MAINTENANCE	0


### PR DESCRIPTION
o Add new CVar "**mp_plant_c4_delay**" to control the "waiting delay" before planting the C4 (works for both normal & plant anywhere modes).
o Rename CCSPlayer's API member "**m_bPPlantC4Anywhere**" into "**m_iCanPlantC4Anywhere**" & extend its behaviour by allowing a specific client to do not have the "plant C4 anywhere" active while the CVar "mp_plant_c4_anywhere" can be.
o Add new CCSPlayer's API member "**m_flPlantC4Delay**" which works the same way as above, and also for both normal & plant anywhere modes.
o Fix C4 icon unblinked on situations where it should not (like if you receive one via "GiveNamedItemEx" and when you are on site, icon unblinked before).
o Fix C4 planting capabilities left once a player has planted the C4 and if he still have some C4 in BP ammo.
  Note: This fix does not allow the game to handle properly "multiple C4 support", other parts in the code (like in "CBasePlayer::DropPlayerItem", CHLMP's "m_bBombDropped", etc.) might need a deeper rework for this, I might do that later, but this is more to handle extra plugins which can give more than 1 C4, not a regular game behaviour.