### PR TITLE
Semiclip fix test for players names aimed (RauliTop's request).

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   windows:
     name: 'Windows'
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     env:
       solution: 'msvc/ReGameDLL.sln'

--- a/regamedll/dlls/player.cpp
+++ b/regamedll/dlls/player.cpp
@@ -7758,7 +7758,11 @@ void CBasePlayer::UpdateStatusBar()
 	Vector vecSrc = EyePosition();
 	Vector vecEnd = vecSrc + (gpGlobals->v_forward * ((pev->flags & FL_SPECTATOR) != 0 ? MAX_SPEC_ID_RANGE : MAX_ID_RANGE));
 
+	int iSolidityTypeArray[MAX_CLIENTS + 1];
+	int iClientsBits = UTIL_GetClientsSolidity(iSolidityTypeArray); // Store solidity.
+	iClientsBits     = UTIL_SetClientsSolidity(iClientsBits, false, SOLID_SLIDEBOX); // Set solidity.
 	UTIL_TraceLine(vecSrc, vecEnd, dont_ignore_monsters, edict(), &tr);
+	UTIL_SetClientsSolidity(iClientsBits, true, 0, iSolidityTypeArray); // Restore solidity.
 
 	if (tr.flFraction != 1.0f)
 	{

--- a/regamedll/dlls/util.cpp
+++ b/regamedll/dlls/util.cpp
@@ -1853,3 +1853,43 @@ int UTIL_CountPlayersInBrushVolume(bool bOnlyAlive, CBaseEntity *pBrushEntity, i
 
 	return playersInCount + playersOutCount;
 }
+
+int UTIL_GetClientsSolidity(int iSolidityTypeArray[MAX_CLIENTS + 1]) {
+	Q_memset(iSolidityTypeArray, SOLID_NOT, sizeof(iSolidityTypeArray));
+
+	int iClientsBitsFound = 0;
+	for(int iClientID = 1; iClientID <= gpGlobals->maxClients; iClientID++)
+	{
+		CBasePlayer *pPlayer = UTIL_PlayerByIndex(iClientID);
+
+		if (!pPlayer || pPlayer->has_disconnected || !pPlayer->IsAlive())
+			continue;
+
+		iSolidityTypeArray[iClientID] = pPlayer->pev->solid;
+		iClientsBitsFound |= (1<<(iClientID - 1));
+	}
+
+	return iClientsBitsFound;	
+}
+
+int UTIL_SetClientsSolidity(int iClientsBitsToSet, bool bSetFromArray, int iSolidityType, int iSolidityTypeArray[MAX_CLIENTS + 1]) {
+	if(iClientsBitsToSet == 0)
+			return 0;
+	
+	int iClientsBitsSet = 0;
+	for(int iClientID = 1; iClientID <= gpGlobals->maxClients; iClientID++)
+	{
+		CBasePlayer *pPlayer = UTIL_PlayerByIndex(iClientID);
+
+		if (!pPlayer || pPlayer->has_disconnected || !pPlayer->IsAlive())
+			continue;
+
+		if(!(iClientsBitsToSet & (1<<(iClientID - 1))))
+				continue;
+
+		pPlayer->pev->solid = (bSetFromArray == false) ? iSolidityType : iSolidityTypeArray[iClientID];
+		iClientsBitsSet |= (1<<(iClientID - 1));
+	}
+
+	return iClientsBitsSet;
+}

--- a/regamedll/dlls/util.h
+++ b/regamedll/dlls/util.h
@@ -354,6 +354,8 @@ public:
 };
 
 int UTIL_CountPlayersInBrushVolume(bool bOnlyAlive, CBaseEntity *pBrushEntity, int &playersInCount, int &playersOutCount, CPlayerInVolumeAdapter *pAdapter = nullptr);
+int UTIL_GetClientsSolidity(int iSolidityTypeArray[MAX_CLIENTS + 1]);
+int UTIL_SetClientsSolidity(int iClientsBitsToSet, bool bSetFromArray, int iSolidityType, int iSolidityTypeArray[MAX_CLIENTS + 1] = nullptr);
 
 inline real_t UTIL_FixupAngle(real_t v)
 {


### PR DESCRIPTION
Fix players names (via message "StatusBar) not showing when aiming at them with semiclip modules/plugins using bad methods.
This will fix "mp_playerid" names feature & AMX[X]'s "PlayerName" stats (HUD names when aiming).